### PR TITLE
feat: add nerdbank versioning and appbar version display (#3)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.*" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ The application uses Entity Framework Core with SQL Server. Configure your conne
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+### Merge Strategy
+
+- Pull requests into `master` must use **Squash and merge** only.
+- Do not use merge commits or rebase merges for `master`.
+- This keeps Nerdbank commit height aligned with one commit per merged PR on `master`.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/WelpenWache/Components/Layout/MainLayout.razor
+++ b/WelpenWache/Components/Layout/MainLayout.razor
@@ -1,4 +1,4 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 <MudThemeProvider @ref="_mudThemeProvider" @bind-IsDarkMode="_isDarkMode" Theme="_accuminTheme"/>
 <MudPopoverProvider/>
 <MudSnackbarProvider/>
@@ -10,10 +10,13 @@
 <MudLayout>
     <MudAppBar Elevation="1">
         <MudIcon Class="text-white" Icon="@Icons.Material.Filled.Pets" Title="Favorite"/>
-        <MudText Typo="Typo.h5" Class="ml-3 text-white">WelpenWache</MudText>
+        <MudStack Spacing="0" Class="ml-3 appbar-title">
+            <MudText Typo="Typo.h5" Class="text-white">WelpenWache</MudText>
+            <MudText Typo="Typo.caption" Class="appbar-version">@_appVersion</MudText>
+        </MudStack>
         <MudSpacer/>
         <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)"
-                       aria-label="delete" Class="appbarIconButton" OnClick="DarkmodeToggle"/>
+                       aria-label="toggle color mode" Class="appbarIconButton" OnClick="DarkmodeToggle"/>
     </MudAppBar>
         <MudDrawer Open ClipMode="DrawerClipMode.Docked" Elevation="2" Variant="DrawerVariant.Mini"
                    Class="rounded-appbar">
@@ -27,6 +30,8 @@
 </MudLayout>
 
 @code {
+    private static readonly string _appVersion = ThisAssembly.AssemblyInformationalVersion;
+
     private bool _isDarkMode;
     private MudThemeProvider _mudThemeProvider = null!;
 

--- a/WelpenWache/Components/Layout/MainLayout.razor.css
+++ b/WelpenWache/Components/Layout/MainLayout.razor.css
@@ -70,9 +70,29 @@ main {
         width: 0;
     }
 
-    .top-row, article {
+.top-row, article {
         padding-left: 2rem !important;
         padding-right: 1.5rem !important;
+    }
+}
+
+.appbar-title {
+    line-height: 1.1;
+}
+
+.appbar-version {
+    color: rgba(255, 255, 255, 0.85);
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+}
+
+@media (max-width: 640.98px) {
+    .appbar-version {
+        max-width: 55vw;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0-beta",
+  "gitCommitIdShortFixedLength": 7
+}


### PR DESCRIPTION
## Summary

  This PR implements issue #3 by introducing repository-wide
  Nerdbank versioning and displaying the app version in the top
  app bar.

  ## Changes

  - Added Nerdbank.GitVersioning for the whole repository via
    Directory.Build.props.
  - Added version.json with:
      - base version: 1.0-beta
      - fixed short git commit length: 7
  - Updated MainLayout to display the informational version
    using ThisAssembly.AssemblyInformationalVersion.
  - Added app bar styling for the version subtitle with
    responsive truncation behavior on small screens.
  - Documented merge policy in README.md:
      - PRs into master must use Squash and merge only.

  ## Why

  - Provides consistent, traceable version metadata tied to git
    state.
  - Makes the running app version visible directly in the UI.
  - Ensures commit height semantics on master align with one
    merged PR = one commit (via squash-only policy).

  ## Validation

  - dotnet build WelpenWache\WelpenWache.csproj -c Release
    succeeds

  ## Related

  - Closes #3