### PR TITLE
feat(layout): add GitHub icon button in app bar

### DIFF
--- a/WelpenWache/Components/Layout/MainLayout.razor
+++ b/WelpenWache/Components/Layout/MainLayout.razor
@@ -15,6 +15,11 @@
             <MudText Typo="Typo.caption" Class="appbar-version">@_appVersion</MudText>
         </MudStack>
         <MudSpacer/>
+        <MudIconButton Icon="@Icons.Custom.Brands.GitHub"
+                       aria-label="GitHub Repository"
+                       Href="@RepositoryUrl"
+                       Target="_blank"
+                       Class="appbarIconButton"/>
         <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)"
                        aria-label="toggle color mode" Class="appbarIconButton" OnClick="DarkmodeToggle"/>
     </MudAppBar>
@@ -30,6 +35,7 @@
 </MudLayout>
 
 @code {
+    private const string RepositoryUrl = "https://github.com/sirkyomi/WelpenWache";
     private static readonly string _appVersion = ThisAssembly.AssemblyInformationalVersion;
 
     private bool _isDarkMode;


### PR DESCRIPTION
Add a MudBlazor GitHub brand icon button to the top-right app bar and link it to the repository in a new tab.